### PR TITLE
✨ feat : RepoDetail과 ResultField props 연결

### DIFF
--- a/src/components/RepoDetail.jsx
+++ b/src/components/RepoDetail.jsx
@@ -1,18 +1,21 @@
 import React from 'react';
 import styled from 'styled-components';
-
-const RepoDetail = () => {
+import PropTypes from 'prop-types';
+const RepoDetail = ({ detailContent }) => {
+  console.log(detailContent.avatar_url);
   return (
     <Wrapper>
-      <ProfilePic />
-      <RepoName>user_name/selected_repo_name=fullname</RepoName>
-      <RepoDesc>repo description repo description</RepoDesc>
-      <RepoUpdated>Updated on 2022-01-18</RepoUpdated>
+      <ProfilePic img={detailContent.avatar_url} />
+      <RepoName>{detailContent.full_name}</RepoName>
+      <RepoDesc>{detailContent.description}</RepoDesc>
+      <RepoUpdated>Updated on {detailContent.updated_at}</RepoUpdated>
       <SaveBtn>저 장</SaveBtn>
     </Wrapper>
   );
 };
-
+RepoDetail.propTypes = {
+  detailContent: PropTypes.object,
+};
 const Wrapper = styled.nav`
   background-color: #fff;
   width: 100%;
@@ -24,6 +27,10 @@ const Wrapper = styled.nav`
 `;
 
 const ProfilePic = styled.div`
+  background-image: url(${({ img }) => img});
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: 150px;
   width: 150px;
   height: 150px;
   border-radius: 50%;

--- a/src/components/ResultField.jsx
+++ b/src/components/ResultField.jsx
@@ -5,7 +5,7 @@ import { useRepoResults } from '../util/axios';
 import Pagination from './Pagination';
 
 // eslint-disable-next-line react/prop-types
-const ResultField = ({ inputValue, setInputValue }) => {
+const ResultField = ({ inputValue, setInputValue, clickRepo }) => {
   const queryClient = useQueryClient();
   const [page, setPage] = useState(1);
 
@@ -15,8 +15,8 @@ const ResultField = ({ inputValue, setInputValue }) => {
     setInputValue(name);
   };
 
-  const onClickEvent = () => {
-    console.log('이동 준비중');
+  const onClickEvent = (id, full_name, description, updated_at, avatar_url) => {
+    clickRepo(id, full_name, description, updated_at, avatar_url);
   };
 
   const getDataByStatus = useCallback(() => {
@@ -30,15 +30,27 @@ const ResultField = ({ inputValue, setInputValue }) => {
           <>
             {data
               ? data.items?.map(item => {
-                  const { id, full_name, decription, updated_at, owner } = item;
+                  const { id, full_name, description, updated_at, owner } =
+                    item;
                   const { avatar_url } = owner;
                   return (
-                    <Box key={id} onClick={onClickEvent}>
+                    <Box
+                      key={id}
+                      onClick={() => {
+                        onClickEvent(
+                          id,
+                          full_name,
+                          description,
+                          updated_at,
+                          avatar_url,
+                        );
+                      }}
+                    >
                       <Content>
                         <img src={avatar_url} alt={name} />
                         <div>
                           <h3>{full_name}</h3>
-                          <p>{decription}</p>
+                          <p>{description}</p>
                           <span>{updated_at}</span>
                         </div>
                       </Content>

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -13,6 +13,7 @@ const Main = () => {
   const queryClient = new QueryClient();
   const [changeValue, setChangeValue] = useState('');
   const [inputValue, setInputValue] = useState('');
+  const [detailContent, setDetailContent] = useState({});
   const searchInput = val => {
     setInputValue(val);
   };
@@ -27,6 +28,9 @@ const Main = () => {
   const clickBtn = () => {
     searchInput(changeValue);
   };
+  const clickRepo = (id, full_name, description, updated_at, avatar_url) => {
+    setDetailContent({ id, full_name, description, updated_at, avatar_url });
+  };
 
   return (
     <MainWrap>
@@ -40,9 +44,13 @@ const Main = () => {
             clickBtn={clickBtn}
           />
           <br />
-          <ResultField inputValue={inputValue} setInputValue={setInputValue} />
+          <ResultField
+            inputValue={inputValue}
+            setInputValue={setInputValue}
+            clickRepo={clickRepo}
+          />
         </Container>
-        <RepoDetail />
+        <RepoDetail detailContent={detailContent} />
       </QueryClientProvider>
     </MainWrap>
   );


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가

### 반영 브랜치
feat/connectMainDetail -> develop

### 변경 사항
1. 오타수정 -> decription에서 description으로 오타 수정
2. Main.jsx에서 useState로 `detailContent` 상태를 
클릭시 ResultField.jsx의 `clickRepo` 이벤트를 통해 데이터를 받아
`detailContent`를 수정하고 이에 영향을 받아
` <RepoDetail detailContent={detailContent} />` props로 내려주어 관련 부분들을 채워준다. 